### PR TITLE
ci: adopt Nix and improve build.sh

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -16,16 +16,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
 
-      - name: Install Vivid
-        run: cargo install vivid
+      - name: Install Nix
+        uses: cachix/install-nix-action@v20
 
       - name: Build plugins
-        run: ./build.sh
+        run: |
+          nix shell nixpkgs#vivid
+          ./build.sh
 
       - name: Commit and push
         uses: EndBug/add-and-commit@v9

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -22,8 +22,8 @@ jobs:
 
       - name: Build plugins
         run: |
-          nix shell nixpkgs#vivid
-          ./build.sh
+          nix shell nixpkgs#{bash,coreutils,vivid} \
+            -i --command bash -c './build.sh'
 
       - name: Commit and push
         uses: EndBug/add-and-commit@v9

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 mkdir -p "plugins"
 

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 mkdir -p "plugins"
 
 for theme in $(vivid themes); do
-    echo "export LS_COLORS=\"$(vivid generate $theme)\"" > "plugins/vivid-$theme.zsh"
+    echo "export LS_COLORS=\"$(vivid generate "$theme")\"" > "plugins/vivid-$theme.zsh"
 done


### PR DESCRIPTION
used `/usr/bin/env bash` as that is more universal across platforms. ci will also use nix over `cargo install`, making things a bit faster :)